### PR TITLE
Changed control flow for error handling of the client to match statement

### DIFF
--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -24,7 +24,7 @@ async fn main() {
         .email("email@example.com")
         .amount("200000")
         .currency(Currency::NGN)
-        .channels(vec![Channel::Qr, Channel::Ussd, Channel::BankTransfer])
+        .channels(vec![Channel::Card])
         .build()
         .unwrap();
 


### PR DESCRIPTION
In this pull request, I changed the error handling for the API client to `match-statements` instead of `if-statements`. The logic for the change is that the `match-statement` allow the API client to handle the successful results expected from the API properly and then treat all other results as an API error, this also reduces the risk of not capturing some edge cases with the `if-statement`.