### PR TITLE
added get and post functions to reduce repetition

### DIFF
--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -1,8 +1,10 @@
 mod charge;
 mod paystack_enums;
 mod transaction;
+mod transaction_split;
 
 // public re-export
 pub use charge::*;
 pub use paystack_enums::*;
 pub use transaction::*;
+pub use transaction_split::*;

--- a/src/resources/paystack_enums.rs
+++ b/src/resources/paystack_enums.rs
@@ -6,10 +6,11 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 /// Respresents the currencies supported by Paystack
 pub enum Currency {
     /// Nigerian Naira
+    #[default]
     NGN,
     /// Ghanian Cedis
     GHS,

--- a/src/resources/transaction.rs
+++ b/src/resources/transaction.rs
@@ -3,8 +3,7 @@
 //! This file contains all the structs and definitions needed to
 //! create a transaction using the paystack API.
 
-use crate::error::PaystackError;
-use crate::{Channel, Currency, PaystackResult};
+use crate::{error::PaystackError, Channel, Currency, PaystackResult};
 use serde::Serialize;
 
 /// This struct is used to create a transaction body for creating a transaction using the Paystack API.
@@ -15,7 +14,7 @@ use serde::Serialize;
 ///     - amount: Amount should be in the smallest unit of the currency e.g. kobo if in NGN and cents if in USD
 ///     - email: Customer's email address
 ///     - currency (Optional): Currency in which amount should be charged (NGN, GHS, ZAR or USD). Defaults to your integration currency.
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Default)]
 pub struct Transaction {
     amount: String,
     email: String,
@@ -94,7 +93,7 @@ impl TransactionBuilder {
 ///     - currency : Currency in which amount should be charged (NGN, GHS, ZAR or USD). Defaults to your integration currency.
 ///     - reference (Optional): Unique transaction reference.
 ///     - at_least: Minimum amount to charge
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct PartialDebitTransaction {
     authorization_code: String,
     amount: String,

--- a/src/resources/transaction_split.rs
+++ b/src/resources/transaction_split.rs
@@ -1,0 +1,6 @@
+//! Transaction Split
+//! =================
+//! This file contains the structs and definitions need to create
+//! transaction splits for the Paystack API.
+
+use crate::{error, Channel, Currency, PaystackResult};

--- a/tests/api/transaction.rs
+++ b/tests/api/transaction.rs
@@ -92,6 +92,7 @@ async fn valid_transaction_is_verified() {
         .expect("unable to verify transaction");
 
     // Assert
+    // println!("{:#?}", response);
     assert!(response.status);
     assert_eq!(response.message, "Verification successful");
     assert!(response.data.status.is_some());
@@ -172,6 +173,7 @@ async fn view_transaction_timeline_passes_with_id() {
         .expect("unable to get transaction timeline");
 
     // Assert
+    // println!("{:#?}", transaction_timeline);
     assert!(transaction_timeline.status);
     assert_eq!(transaction_timeline.message, "Timeline retrieved");
 }


### PR DESCRIPTION
Added `get_request` and `post_request` methods to the API client class. These functions are private to the client.

The logic behind this decision is that there is a lot of repetition of either post or get requests in the different methods of the API client. This has the potential to cause cumbersome error-handling issues from the HTTP request, thus having them in their specific method limits the error handling to just those methods. 

This change also makes the maintenance of the client easier in the long run.