### PR TITLE
Implemented the Transaction Split API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paystack-rs"
-version = "0.1.5"
+version = "0.1.6" # updated version number already
 description = "A unofficial client library for the Paystack API"
 authors = ["Oghenemarho Orukele <orukele.dev@gmail.com>"]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Convenient **Async** rust bindings and types for the Paystack HTTP API aiming to
 The client current covers the follow section of the API:
 
 - Transactions
+- Transaction Splits
 
 ## Documentation
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,10 @@ pub enum PaystackError {
     #[error("Charge Error: {0}")]
     Charge(String),
 
+    /// Error associated with Transaction Split
+    #[error("Transaction Split Error: {0}")]
+    TransactionSplit(String),
+
     /// Error for unsuccessful request to the Paystack API
     #[error("Request failed: `{0}`")]
     RequestNotSuccessful(#[from] RequestNotSuccessful),

--- a/src/resources/charge.rs
+++ b/src/resources/charge.rs
@@ -4,6 +4,7 @@
 //! create charges usingt the Paystack API.
 
 use crate::{error, Channel, Currency, PaystackResult};
+use serde::Serialize;
 
 /// This struct is used to create a charge body for creating a Charge Authorization using the Paystack API.
 ///
@@ -24,7 +25,7 @@ use crate::{error, Channel, Currency, PaystackResult};
 ///     Ideally, you will need to use this if you are splitting in flat rates
 ///     (since subaccount creation only allows for percentage split). e.g. 7000 for a 70 naira
 
-#[derive(serde::Serialize, Debug)]
+#[derive(Serialize, Debug)]
 pub struct Charge {
     email: String,
     amount: String,
@@ -35,7 +36,29 @@ pub struct Charge {
     transaction_charge: Option<u32>,
 }
 
-/// Builder for the Charge object
+/// The `ChargeBuilder` struct provides a convenient way to construct a charge object
+/// with optional fields. Each field can be set individually using the builder's methods.
+/// Once all the desired fields are set, the `build` method can be called to create
+/// an instance of the `Charge` struct.
+///
+/// # Errors
+///
+/// Returns a `PaystackResult` with an `Err` variant if any required fields are missing,
+/// including email, amount, and authorization code. The error indicates which field is missing.
+///
+/// # Examples
+///
+/// ```rust
+/// use paystack::{Currency, Channel, ChargeBuilder};
+///
+/// let charge = ChargeBuilder::new()
+///         .email("user@example.com")
+///         .amount("10000")
+///         .authorization_code("AUTH_CODE")
+///         .currency(Currency::USD)
+///         .channel(vec![Channel::Card, Channel::Bank])
+///         .build();
+/// ```
 #[derive(Default, Clone)]
 pub struct ChargeBuilder {
     email: Option<String>,

--- a/src/resources/paystack_enums.rs
+++ b/src/resources/paystack_enums.rs
@@ -6,8 +6,38 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+/// Represents different currencies supported by the Paystack API.
+///
+/// The `Currency` enum defines the possible currency options that can be used with Paystack,
+/// including Nigerian Naira (NGN), Ghanaian Cedis (GHS), American Dollar (USD),
+/// and South African Rands (ZAR). It also includes an `EMPTY` variant to represent cases
+/// where the currency can be empty.
+///
+/// # Variants
+///
+/// - `NGN`: Nigerian Naira.
+/// - `GHS`: Ghanaian Cedis.
+/// - `USD`: American Dollar.
+/// - `ZAR`: South African Rands.
+/// - `EMPTY`: Used when the currency can be empty.
+///
+/// # Examples
+///
+/// ```
+/// use paystack::Currency;
+///
+/// let ngn_currency = Currency::NGN;
+/// let ghs_currency = Currency::GHS;
+/// let usd_currency = Currency::USD;
+/// let zar_currency = Currency::ZAR;
+/// let empty_currency = Currency::EMPTY;
+///
+/// println!("{:?}", ngn_currency); // Prints: NGN
+/// ```
+///
+/// The example demonstrates the usage of the `Currency` enum from the Paystack crate,
+/// creating instances of each variant and printing their debug representation.
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
-/// Respresents the currencies supported by Paystack
 pub enum Currency {
     /// Nigerian Naira
     #[default]
@@ -35,11 +65,45 @@ impl fmt::Display for Currency {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+/// Represents the payment channels supported by Paystack.
+///
+/// The `Channel` enum defines the possible payment channels that can be used with Paystack,
+/// including debit card, bank interface, USSD code, QR code, mobile money, bank transfer,
+/// and Apple Pay.
+///
+/// # Variants
+///
+/// - `Card`: Payment with a debit card.
+/// - `Bank`: Payment with a bank interface.
+/// - `Ussd`: Payment with a USSD code.
+/// - `Qr`: Payment with a QR code.
+/// - `MobileMoney`: Payment with mobile money.
+/// - `BankTransfer`: Payment with a bank transfer.
+/// - `ApplePay`: Payment with Apple Pay.
+///
+/// # Examples
+///
+/// ```
+/// use paystack::Channel;
+///
+/// let card_channel = Channel::Card;
+/// let bank_channel = Channel::Bank;
+/// let ussd_channel = Channel::Ussd;
+/// let qr_channel = Channel::Qr;
+/// let mobile_money_channel = Channel::MobileMoney;
+/// let bank_transfer_channel = Channel::BankTransfer;
+/// let apple_pay_channel = Channel::ApplePay;
+///
+/// println!("{:?}", card_channel); // Prints: Card
+/// ```
+///
+/// The example demonstrates the usage of the `Channel` enum from the Paystack crate,
+/// creating instances of each variant and printing their debug representation.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "snake_case")]
-/// Represents the payment channels supported by Paystack
 pub enum Channel {
     /// Debit Card
+    #[default]
     Card,
     /// Payment with Bank Interface
     Bank,
@@ -61,9 +125,33 @@ impl fmt::Display for Channel {
     }
 }
 
+/// Represents the status of a transaction.
+///
+/// The `Status` enum defines the possible status values for a transaction,
+/// indicating whether the transaction was successful, abandoned, or failed.
+///
+/// # Variants
+///
+/// - `Success`: Represents a successful transaction.
+/// - `Abandoned`: Represents an abandoned transaction.
+/// - `Failed`: Represents a failed transaction.
+///
+/// # Examples
+///
+/// ```
+/// use paystack::Status;
+///
+/// let success_status = Status::Success;
+/// let abandoned_status = Status::Abandoned;
+/// let failed_status = Status::Failed;
+///
+/// println!("{:?}", success_status); // Prints: Success
+/// ```
+///
+/// The example demonstrates the usage of the `Status` enum, creating instances of each variant
+/// and printing their debug representation.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
-/// Represents the status of the Transaction.
 pub enum Status {
     /// A successful transaction.
     Success,
@@ -79,6 +167,103 @@ impl fmt::Display for Status {
             Status::Success => "success",
             Status::Abandoned => "abandoned",
             Status::Failed => "failed",
+        };
+        write!(f, "{}", lowercase_string)
+    }
+}
+
+/// Represents the type of transaction split.
+///
+/// The `SplitType` enum defines the possible types of transaction splits that can be created,
+/// indicating whether the split is based on a percentage or a flat amount.
+///
+/// # Variants
+///
+/// - `Percentage`: A split based on a percentage.
+/// - `Flat`: A split based on an amount.
+///
+/// # Examples
+///
+/// ```
+/// use paystack::SplitType;
+///
+/// let percentage_split = SplitType::Percentage;
+/// let flat_split = SplitType::Flat;
+///
+/// println!("{:?}", percentage_split); // Prints: Percentage
+/// ```
+///
+/// The example demonstrates the usage of the `SplitType` enum, creating instances of each variant
+/// and printing their debug representation.
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SplitType {
+    /// A split based on a percentage
+    #[default]
+    Percentage,
+    /// A split based on an amount
+    Flat,
+}
+
+impl fmt::Display for SplitType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lowercase_string = match self {
+            SplitType::Percentage => "percentage",
+            SplitType::Flat => "flat",
+        };
+        write!(f, "{}", lowercase_string)
+    }
+}
+
+/// Represents the type of bearer for a charge.
+///
+/// The `BearerType` enum defines the possible types of bearers for a charge, indicating who
+/// is responsible for the transaction split.
+///
+/// # Variants
+///
+/// - `Subaccount`: The subaccount bears the transaction split.
+/// - `Account`: The main account bears the transaction split.
+/// - `AllProportional`: The transaction is split proportionally to all accounts.
+/// - `All`: The transaction is paid by all accounts.
+///
+/// # Examples
+///
+/// ```
+/// use paystack::BearerType;
+///
+/// let subaccount_bearer = BearerType::Subaccount;
+/// let account_bearer = BearerType::Account;
+/// let all_proportional_bearer = BearerType::AllProportional;
+/// let all_bearer = BearerType::All;
+///
+/// println!("{:?}", subaccount_bearer); // Prints: Subaccount
+/// ```
+///
+/// The example demonstrates the usage of the `BearerType` enum, creating instances of each variant
+/// and printing their debug representation.
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum BearerType {
+    /// The subaccount bears the transaction split
+    #[default]
+    Subaccount,
+    /// The main account bears the transaction split
+    Account,
+    /// The transaction is split proportionally to all accounts
+    #[serde(rename = "all-proportional")]
+    AllProportional,
+    /// The transaction is paid by all accounts
+    All,
+}
+
+impl fmt::Display for BearerType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lowercase_string = match self {
+            BearerType::Subaccount => "subaccount",
+            BearerType::Account => "account",
+            BearerType::AllProportional => "all-proportional",
+            BearerType::All => "all",
         };
         write!(f, "{}", lowercase_string)
     }

--- a/src/resources/transaction_split.rs
+++ b/src/resources/transaction_split.rs
@@ -3,4 +3,191 @@
 //! This file contains the structs and definitions need to create
 //! transaction splits for the Paystack API.
 
-use crate::{error, Channel, Currency, PaystackResult};
+use crate::{error::PaystackError, BearerType, Currency, PaystackResult, SplitType};
+use serde::Serialize;
+
+/// This struct is used to create a split payment on your integration.
+///
+/// IMPORTANT: This class can obly be created using the TransactionSplitBuilder.
+/// THe struct has the following fields:
+///     - name: Name of the transaction split
+///     - type: The type of transaction split you want to create.
+///       You can use one of the following: percentage | flat.
+///     - currency: Any of NGN, GHS, ZAR, or USD
+///     - subaccounts: A list of object containing subaccount
+///       code and number of shares
+///     - bearer_type: Any of subaccount | account | all-proportional | all
+///     - bearer_subaccount: Subaccount code
+#[derive(Serialize, Debug, Default)]
+pub struct TransactionSplit {
+    name: String,
+    #[serde(rename = "type")]
+    split_type: SplitType,
+    currency: Currency,
+    subaccounts: Vec<Subaccount>,
+    bearer_type: BearerType,
+    bearer_subaccount: String,
+}
+
+/// This struct represents the subacount that bears the transaction split
+#[derive(Serialize, Debug, Clone)]
+pub struct Subaccount {
+    /// This is the sub account code
+    pub subaccount: String,
+    /// This is the transaction share for the subaccount
+    pub share: u32,
+}
+
+impl Subaccount {
+    /// Creates a new subaccount for the Paystack API
+    pub fn new(subaccount: impl Into<String>, share: u32) -> Self {
+        Subaccount {
+            subaccount: subaccount.into(),
+            share,
+        }
+    }
+}
+
+/// A builder pattern implementation for constructing `PercentageSplit` instances.
+///
+/// The `PercentageSplitBuilder` struct provides a fluent and readable way to construct
+/// instances of the `PercentageSplit` struct.
+///
+/// # Errors
+///
+/// Returns a `PaystackResult` with an `Err` variant if any required fields are missing,
+/// including email, amount, and currency. The error indicates which field is missing.
+///
+/// # Examples
+///
+/// ```rust
+/// use paystack::{Currency, SplitType, BearerType, PercentageSplitBuilder, Subaccount};
+///
+/// let sub_accounts = vec![
+///     Subaccount::new(
+///         "ACCT_z3x6z3nbo14xsil",
+///         20,
+///     ),
+///     Subaccount::new(
+///         "ACCT_pwwualwty4nhq9d",
+///         30,
+///     ),
+/// ];
+///
+/// let percentage_split = PercentageSplitBuilder::new()
+///     .name("Percentage Split")
+///     .split_type(SplitType::Percentage)
+///     .currency(Currency::NGN)
+///     .add_subaccount(sub_accounts)
+///     .bearer_type(BearerType::Subaccount)
+///     .bearer_subaccount("ACCT_hdl8abxl8drhrl3")
+///     .build();
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct PercentageSplitBuilder {
+    name: Option<String>,
+    split_type: Option<SplitType>,
+    currency: Option<Currency>,
+    subaccounts: Option<Vec<Subaccount>>,
+    bearer_type: Option<BearerType>,
+    bearer_subaccount: Option<String>,
+}
+
+impl PercentageSplitBuilder {
+    /// Create a new instance of the Percentage Split builder with default properties
+    pub fn new() -> Self {
+        PercentageSplitBuilder::default()
+    }
+
+    /// Specify the transaction split name
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Specify the transaction split amount
+    pub fn split_type(mut self, split_type: SplitType) -> Self {
+        self.split_type = Some(split_type);
+        self
+    }
+
+    /// Specify the transaction split currency
+    pub fn currency(mut self, currency: Currency) -> Self {
+        self.currency = Some(currency);
+        self
+    }
+
+    /// Specify the subaccount for the transaction split
+    pub fn add_subaccount(mut self, sub_accounts: Vec<Subaccount>) -> Self {
+        self.subaccounts = Some(sub_accounts);
+        self
+    }
+
+    /// Specify the bearer type for the transaction split
+    pub fn bearer_type(mut self, bearer_type: BearerType) -> Self {
+        self.bearer_type = Some(bearer_type);
+        self
+    }
+
+    /// Specify the bearer subaccount code
+    pub fn bearer_subaccount(mut self, code: impl Into<String>) -> Self {
+        self.bearer_subaccount = Some(code.into());
+        self
+    }
+
+    /// Build the TransactionSplit object
+    pub fn build(self) -> PaystackResult<TransactionSplit> {
+        let Some(name) = self.name else {
+            return Err(
+                PaystackError::TransactionSplit("name is required to create a transaction split".to_string())
+            )
+        };
+
+        let Some(split_type) = self.split_type else {
+            return Err(
+                PaystackError::TransactionSplit("split type is required to create a transaction split".to_string())
+            )
+        };
+
+        let Some(currency) = self.currency else {
+            return Err(
+                PaystackError::Transaction(
+                    "currency is required to create a transaction split".to_string()
+                )
+            )
+        };
+
+        let Some(subaccounts) = self.subaccounts else {
+            return Err(
+                PaystackError::TransactionSplit(
+                    "sub accounts are required to create a transaction split".to_string()
+                )
+            )
+        };
+
+        let Some(bearer_type) = self.bearer_type else {
+            return Err(
+                PaystackError::TransactionSplit(
+                    "bearer type is required to create a transaction split".to_string()
+                )
+            )
+        };
+
+        let Some(bearer_subaccount) = self.bearer_subaccount else {
+            return Err(
+                PaystackError::TransactionSplit(
+                    "bearer subaccount is required to create a transaction split".to_string()
+                )
+            )
+        };
+
+        Ok(TransactionSplit {
+            name,
+            split_type,
+            currency,
+            subaccounts,
+            bearer_type,
+            bearer_subaccount,
+        })
+    }
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -49,8 +49,6 @@ pub struct TransactionStatusList {
     /// This contains the results of your request.
     /// In this case, it is a vector of objects.
     pub data: Vec<TransactionStatusData>,
-    /// This contains the meta data associated with the response.
-    pub meta: MetaData,
 }
 
 /// This struct represents the transaction timeline.
@@ -97,26 +95,6 @@ pub struct TranasctionHistory {
     pub message: String,
     /// Time action was taken in ms.
     pub time: u32,
-}
-
-/// This struct represents the mata data of the response.
-#[derive(Deserialize, Debug, Clone)]
-pub struct MetaData {
-    /// This is the total number of transactions that were performed by the customer.
-    pub total: Option<u32>,
-    /// This is the number of records skipped before the first record in the array returned.
-    pub skipped: Option<u32>,
-    /// This is the maximum number of records that will be returned per request.
-    /// This can be modified by passing a new value as a perPage query parameter. Default: 50
-    pub per_page: Option<u32>,
-    /// This is the current page being returned.
-    /// This is dependent on what page was requested using the page query parameter.
-    ///
-    /// `Default: 1`
-    pub page: Option<u32>,
-    /// This is how many pages in total are available for retrieval considering the maximum records per page specified.
-    /// For context, if there are 51 records and perPage is left at its default value, pageCount will have a value of 2.
-    pub page_count: Option<u32>,
 }
 
 /// This struct represents the data of the transaction status response.
@@ -208,7 +186,7 @@ pub struct Customer {
     pub international_format_phone: Option<String>,
 }
 
-/// Total amount received on your account
+/// Represents the response of the total amount received on your account
 #[derive(Debug, Deserialize)]
 pub struct TransactionTotalsResponse {
     /// This lets you know if your request was succesful or not.
@@ -245,7 +223,7 @@ pub struct VolumeByCurrency {
     pub amount: u32,
 }
 
-/// Result of the export transaction information.
+/// Represents the response of the export transaction.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ExportTransactionResponse {
     /// This lets you know if your request was succesful or not.
@@ -263,7 +241,7 @@ pub struct ExportTransactionData {
     pub path: String,
 }
 
-/// Result of the partial debit transaction.
+/// Represents the response of the partial debit transaction.
 #[derive(Debug, Deserialize)]
 pub struct PartialDebitTransactionResponse {
     /// This lets you know if your request was succesful or not.
@@ -272,4 +250,105 @@ pub struct PartialDebitTransactionResponse {
     pub message: String,
     /// This contains the results of your request.
     pub data: TransactionStatusData,
+}
+
+/// Represents the JSON response containing percentage split information.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TransactionSplitResponse {
+    /// The status of the JSON response.
+    pub status: bool,
+    /// The message associated with the JSON response.
+    pub message: String,
+    /// The percentage split data.
+    pub data: SplitData,
+}
+
+/// Represents the percentage split data received in the JSON response.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SplitData {
+    /// The ID of the percentage split.
+    pub id: u32,
+    /// The name of the percentage split.
+    pub name: String,
+    /// The type of the percentage split.
+    #[serde(rename = "type")]
+    pub split_type: String,
+    /// The currency used for the percentage split.
+    pub currency: String,
+    /// The integration associated with the percentage split.
+    pub integration: u32,
+    /// The domain associated with the percentage split.
+    pub domain: String,
+    /// The split code of the percentage split.
+    pub split_code: String,
+    /// Indicates whether the percentage split is active or not.
+    pub active: Option<bool>,
+    /// The bearer type of the percentage split.
+    pub bearer_type: String,
+    /// The subaccount ID of the bearer associated with the percentage split.
+    pub bearer_subaccount: u32,
+    /// The creation timestamp of the percentage split.
+    pub created_at: String,
+    /// The last update timestamp of the percentage split.
+    pub updated_at: String,
+    /// The list of subaccounts involved in the percentage split.
+    pub subaccounts: Vec<SubaccountData>,
+    /// The total count of subaccounts in the percentage split.
+    pub total_subaccounts: u32,
+}
+
+/// Represents the data of th Subaccounts
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SubaccountData {
+    /// Sub account data
+    pub subaccount: SubaccountResponse,
+    /// Share of split assigned to this sub
+    pub share: u32,
+}
+
+/// Represents a subaccount in the percentage split data.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SubaccountResponse {
+    /// The ID of the subaccount.
+    pub id: u32,
+    /// The code of the subaccount.
+    pub subaccount_code: String,
+    /// The name of the business associated with the subaccount.
+    pub business_name: String,
+    /// The description of the business associated with the subaccount.
+    pub description: String,
+    /// The name of the primary contact for the business, if available.
+    pub primary_contact_name: Option<String>,
+    /// The email of the primary contact for the business, if available.
+    pub primary_contact_email: Option<String>,
+    /// The phone number of the primary contact for the business, if available.
+    pub primary_contact_phone: Option<String>,
+    /// Additional metadata associated with the subaccount, if available.
+    pub metadata: Option<String>,
+    /// The percentage charge for transactions associated with the subaccount.
+    pub percentage_charge: u32,
+    /// The name of the settlement bank for the subaccount.
+    pub settlement_bank: String,
+    /// The account number of the subaccount.
+    pub account_number: String,
+}
+
+/// Represents the JSON response containing percentage split information.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TransactionSplitListResponse {
+    /// The status of the JSON response.
+    pub status: bool,
+    /// The message associated with the JSON response.
+    pub message: String,
+    /// The percentage split data.
+    pub data: Vec<SplitData>,
+}
+
+/// Represents the JSON response of the Paystack API when there is no data property
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResponseWithoutData {
+    /// The status of the JSON response.
+    pub status: bool,
+    /// The message associated with the JSON response.
+    pub message: String,
 }

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,3 +1,4 @@
 pub mod charge;
 pub mod helpers;
 pub mod transaction;
+pub mod transaction_split;

--- a/tests/api/transaction.rs
+++ b/tests/api/transaction.rs
@@ -92,7 +92,6 @@ async fn valid_transaction_is_verified() {
         .expect("unable to verify transaction");
 
     // Assert
-    // println!("{:#?}", response);
     assert!(response.status);
     assert_eq!(response.message, "Verification successful");
     assert!(response.data.status.is_some());
@@ -173,7 +172,6 @@ async fn view_transaction_timeline_passes_with_id() {
         .expect("unable to get transaction timeline");
 
     // Assert
-    // println!("{:#?}", transaction_timeline);
     assert!(transaction_timeline.status);
     assert_eq!(transaction_timeline.message, "Timeline retrieved");
 }
@@ -188,6 +186,8 @@ async fn view_transaction_timeline_passes_with_reference() {
         .list_transactions(Some(1), Some(Status::Success))
         .await
         .expect("unable to get list of integrated transactions");
+
+    // println!("{:#?}", response);
 
     let transaction_timeline = client
         .view_transaction_timeline(None, response.data[0].reference.clone())

--- a/tests/api/transaction_split.rs
+++ b/tests/api/transaction_split.rs
@@ -1,0 +1,1 @@
+// TODO: Test this route only after implementing the subaccounts route for the client


### PR DESCRIPTION
Implemented the Transaction Split route of the Paystack API client. This route allows the user to use the split route of the Paystack API client.

This route has not been extensively tested because the other parts of the API needed to run a test such as creating sub-accounts have not been implemented. 