### PR TITLE
changed all &str to String

### DIFF
--- a/examples/transaction.rs
+++ b/examples/transaction.rs
@@ -21,8 +21,8 @@ async fn main() {
     let client = PaystackClient::new(&api_key);
 
     let body = InitializeTransactionBodyBuilder::default()
-        .amount("10000")
-        .email("email@example.com")
+        .amount("10000".to_string())
+        .email("email@example.com".to_string())
         .currency(Some(Currency::NGN))
         .channels(Some(vec![
             Channel::ApplePay,

--- a/src/endpoints/subaccounts.rs
+++ b/src/endpoints/subaccounts.rs
@@ -31,7 +31,7 @@ impl<'a> SubaccountEndpoints<'a> {
     ///     - body: subaccount to create.
     pub async fn create_subaccount(
         &self,
-        body: CreateSubaccountBody<'a>,
+        body: CreateSubaccountBody,
     ) -> PaystackResult<CreateSubaccountResponse> {
         let url = format!("{}/subaccount", BASE_URL);
 
@@ -124,7 +124,7 @@ impl<'a> SubaccountEndpoints<'a> {
     pub async fn update_subaccount(
         &self,
         id_or_code: &str,
-        body: CreateSubaccountBody<'a>,
+        body: CreateSubaccountBody,
     ) -> PaystackResult<CreateSubaccountResponse> {
         let url = format!("{}/subaccount/{}", BASE_URL, id_or_code);
 

--- a/src/endpoints/terminal.rs
+++ b/src/endpoints/terminal.rs
@@ -2,6 +2,8 @@
 //! ========
 //! The Terminal API allows you to build delightful in-person payment experiences.
 
+use crate::SendEventBody;
+
 /// A Struct to hold all the functions of the terminal API route
 #[derive(Debug, Clone)]
 pub struct TerminalEndpoints<'a> {
@@ -15,4 +17,7 @@ impl<'a> TerminalEndpoints<'a> {
     pub fn new(key: &'a str) -> TerminalEndpoints<'a> {
         TerminalEndpoints { api_key: key }
     }
+
+    /// Send an event from your application to the Paystack Terminal
+    pub async fn send_event(terminal_id: &str, event_body: SendEventBody) {}
 }

--- a/src/endpoints/transaction_splits.rs
+++ b/src/endpoints/transaction_splits.rs
@@ -30,7 +30,7 @@ impl<'a> TransactionSplitEndpoints<'a> {
     /// This method takes a TransactionSplit object as a parameter.
     pub async fn create_transaction_split(
         &self,
-        split_body: CreateTransactionSplitBody<'a>,
+        split_body: CreateTransactionSplitBody,
     ) -> PaystackResult<TransactionSplitResponse> {
         let url = format!("{}/split", BASE_URL);
 
@@ -123,7 +123,7 @@ impl<'a> TransactionSplitEndpoints<'a> {
     pub async fn update_transaction_split(
         &self,
         split_id: &str,
-        body: UpdateTransactionSplitBody<'a>,
+        body: UpdateTransactionSplitBody,
     ) -> PaystackResult<TransactionSplitResponse> {
         let url = format!("{}/split/{}", BASE_URL, split_id);
 

--- a/src/endpoints/transactions.rs
+++ b/src/endpoints/transactions.rs
@@ -30,7 +30,7 @@ impl<'a> TransactionEndpoints<'a> {
     /// It takes a Transaction type as its parameter
     pub async fn initialize_transaction(
         &self,
-        transaction_body: InitializeTransactionBody<'a>,
+        transaction_body: InitializeTransactionBody,
     ) -> PaystackResult<TransactionResponse> {
         let url = format!("{}/transaction/initialize", BASE_URL);
 
@@ -135,7 +135,7 @@ impl<'a> TransactionEndpoints<'a> {
     /// This function takes a Charge Struct as parameter
     pub async fn charge_authorization(
         &self,
-        charge: ChargeBody<'a>,
+        charge: ChargeBody,
     ) -> PaystackResult<TransactionStatusResponse> {
         let url = format!("{}/transaction/charge_authorization", BASE_URL);
 
@@ -268,7 +268,7 @@ impl<'a> TransactionEndpoints<'a> {
     /// NB: it must be created with the PartialDebitTransaction Builder.
     pub async fn partial_debit(
         &self,
-        transaction_body: PartialDebitTransactionBody<'a>,
+        transaction_body: PartialDebitTransactionBody,
     ) -> PaystackResult<TransactionStatusResponse> {
         let url = format!("{}/transaction/partial_debit", BASE_URL);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@
 //!         let client = PaystackClient::new(&api_key);
 //!
 //!         let body = InitializeTransactionBodyBuilder::default()
-//!              .amount("10000")
-//!              .email("email@example.com")
+//!              .amount("10000".to_string())
+//!              .email("email@example.com".to_string())
 //!              .currency(Some(Currency::NGN))
 //!              .channels(Some(vec![
 //!                  Channel::ApplePay,

--- a/src/models/charge.rs
+++ b/src/models/charge.rs
@@ -10,16 +10,16 @@ use serde::Serialize;
 /// This struct is used to create a charge body for creating a Charge Authorization using the Paystack API.
 /// The struct is constructed using the `ChargeBodyBuilder`
 #[derive(Serialize, Debug, Builder)]
-pub struct ChargeBody<'a> {
+pub struct ChargeBody {
     /// Customer's email address
-    email: &'a str,
+    email: String,
     /// Amount should be in the smallest unit of the currency e.g. kobo if in NGN and cents if in USD
-    amount: &'a str,
+    amount: String,
     /// Valid authorization code to charge
-    authorization_code: &'a str,
+    authorization_code: String,
     /// Unique transaction reference. Only `-`, `.`, `=` and alphanumeric characters allowed.
     #[builder(default = "None")]
-    reference: Option<&'a str>,
+    reference: Option<String>,
     /// Currency in which amount should be charged.
     #[builder(default = "None")]
     currency: Option<Currency>,
@@ -28,13 +28,13 @@ pub struct ChargeBody<'a> {
     /// when displayed on the dashboard.
     /// Sample: {"custom_fields":[{"display_name":"Cart ID","variable_name": "cart_id","value": "8393"}]}
     #[builder(default = "None")]
-    metadata: Option<&'a str>,
+    metadata: Option<String>,
     /// Send us 'card' or 'bank' or 'card','bank' as an array to specify what options to show the user paying
     #[builder(default = "None")]
     channel: Option<Vec<Channel>>,
     /// The code for the subaccount that owns the payment. e.g. `ACCT_8f4s1eq7ml6rlzj`
     #[builder(default = "None")]
-    subaccount: Option<&'a str>,
+    subaccount: Option<String>,
     /// A flat fee to charge the subaccount for this transaction in the subunit of the supported currency.
     /// This overrides the split percentage set when the subaccount was created.
     /// Ideally, you will need to use this if you are splitting in flat rates (since subaccount creation only allows for percentage split).
@@ -42,7 +42,7 @@ pub struct ChargeBody<'a> {
     transaction_charge: Option<u32>,
     /// Who bears Paystack charges? account or subaccount (defaults to account).
     #[builder(default = "None")]
-    bearer: Option<&'a str>,
+    bearer: Option<String>,
     /// If you are making a scheduled charge call, it is a good idea to queue them so the processing system does not
     /// get overloaded causing transaction processing errors.
     /// Send queue:true to take advantage of our queued charging.

--- a/src/models/currency.rs
+++ b/src/models/currency.rs
@@ -35,7 +35,7 @@ use std::fmt;
 /// ```
 ///
 /// The example demonstrates the usage of the `Currency` enum from the Paystack crate,
-/// creating instances of each variant and printing their debug representation.
+/// creating instances of each variant and printing a debug representation.
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub enum Currency {
     /// Nigerian Naira

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -7,6 +7,7 @@ pub mod generic;
 pub mod split;
 pub mod status;
 pub mod subaccounts;
+pub mod terminal;
 pub mod transaction_split;
 pub mod transactions;
 
@@ -20,5 +21,6 @@ pub use generic::*;
 pub use split::*;
 pub use status::*;
 pub use subaccounts::*;
+pub use terminal::*;
 pub use transaction_split::*;
 pub use transactions::*;

--- a/src/models/subaccounts.rs
+++ b/src/models/subaccounts.rs
@@ -8,33 +8,33 @@ use serde::{Deserialize, Serialize};
 
 /// This struct is used to create the body for creating a subaccount on your integration.
 #[derive(Serialize, Debug, Builder, Default)]
-pub struct CreateSubaccountBody<'a> {
+pub struct CreateSubaccountBody {
     /// Name of business for subaccount
-    business_name: &'a str,
+    business_name: String,
     /// Bank Code for the bank.
     /// You can get the list of Bank Codes by calling the List Banks endpoint.
-    settlement_bank: &'a str,
+    settlement_bank: String,
     /// Bank Account Number
-    account_number: &'a str,
+    account_number: String,
     /// The default percentage charged when receiving on behalf of this subaccount
     percentage_charge: f32,
     /// A description for this subaccount
-    description: &'a str,
+    description: String,
     /// A contact email for the subaccount
     #[builder(default = "None")]
-    primary_contact_email: Option<&'a str>,
+    primary_contact_email: Option<String>,
     /// A name for the contact person for this subaccount
     #[builder(default = "None")]
-    primary_contact_name: Option<&'a str>,
+    primary_contact_name: Option<String>,
     /// A phone number to call for this subaccount
     #[builder(default = "None")]
-    primary_contact_phone: Option<&'a str>,
+    primary_contact_phone: Option<String>,
     /// Stringified JSON object.
     /// Add a custom_fields attribute which has an array of objects if you would like the fields to be
     /// added to your transaction when displayed on the dashboard.
     /// Sample: {"custom_fields":[{"display_name":"Cart ID","variable_name": "cart_id","value": "8393"}]}
     #[builder(default = "None")]
-    metadata: Option<&'a str>,
+    metadata: Option<String>,
 }
 
 /// This struct represents the subaccount.

--- a/src/models/terminal.rs
+++ b/src/models/terminal.rs
@@ -1,0 +1,87 @@
+//! Terminal Models
+//! ====================
+//! This file contains the models and enums for working with the terminal endpoint.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// This struct is used to create an event body for sending an event to the paystack Terminal using the Paystack API.
+/// This struct should be created using the `SendEventBodyBuilder`
+/// The Builder derivation allows for the automatic implementation of the builder
+#[derive(Deserialize, Serialize)]
+pub struct SendEventBody {
+    event_type: EventType,
+    action: ActionType,
+    data: EventData,
+}
+
+///
+#[derive(Deserialize, Serialize)]
+pub struct EventData {
+    id: String,
+    reference: Option<String>,
+}
+
+///
+#[derive(Deserialize, Serialize)]
+pub enum ActionType {
+    ///
+    Process,
+    ///
+    View,
+    ///
+    Print,
+}
+
+impl fmt::Display for ActionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let action = match self {
+            ActionType::Process => "process",
+            ActionType::View => "view",
+            ActionType::Print => "print",
+        };
+        write!(f, "{}", action)
+    }
+}
+
+/// Represents the different terminal event types supported by the Paystack API.
+///
+/// The `EventType` enum defines the possible even types that can be sent to Paystack Terminal.
+/// The paystack API currently supports `Invoice` and `Transaction`. This list will be periodically updated as the API evolves. Feel free to open a PR if you catch the change before us.
+///
+/// # Variants
+///
+/// - `Invoice`: Invoice event.
+/// - `Transaction`: Transaction event.
+///
+/// # Examples
+///
+/// ```
+/// use paystack::EventType;
+///
+/// let invoice_event = EventType::Invoice;
+/// let terminal_event = EventType::Transaction;
+///
+/// println!("{:?}", invoice_event); // Prints: invoice
+/// ```
+/// The example demonstrates the usage of the `EventType` enum from the Paystack crate, creating instances of each variant and printing a debug representation.
+///
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[non_exhaustive]
+pub enum EventType {
+    /// Invoice event
+    #[default]
+    Invoice,
+    /// Transaction event
+    Transaction,
+}
+
+impl fmt::Display for EventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let terminal_type = match self {
+            EventType::Invoice => "invoice",
+            EventType::Transaction => "transaction",
+        };
+        write!(f, "{}", terminal_type)
+    }
+}

--- a/src/models/transaction_split.rs
+++ b/src/models/transaction_split.rs
@@ -8,9 +8,9 @@ use serde::Serialize;
 /// This struct is used to create a split payment on your integration.
 /// The struct is constructed using the `CreateTransactionSplitBodyBuilder`
 #[derive(Serialize, Debug, Default, Builder)]
-pub struct CreateTransactionSplitBody<'a> {
+pub struct CreateTransactionSplitBody {
     /// Name of the transaction split
-    name: &'a str,
+    name: String,
     /// The type of transaction split you want to create
     #[serde(rename = "type")]
     split_type: SplitType,
@@ -21,15 +21,15 @@ pub struct CreateTransactionSplitBody<'a> {
     /// Any of subaccount
     bearer_type: BearerType,
     /// Subaccount code
-    bearer_subaccount: &'a str,
+    bearer_subaccount: String,
 }
 
 /// This struct is used to update a transaction split details on your integration.
 /// The struct is constructed using the `UpdateTransactionSplitBodyBuilder`
 #[derive(Serialize, Debug, Builder, Default)]
-pub struct UpdateTransactionSplitBody<'a> {
+pub struct UpdateTransactionSplitBody {
     /// Name of the transaction split
-    name: &'a str,
+    name: String,
     /// True or False
     active: bool,
     /// Any of subaccount

--- a/src/models/transactions.rs
+++ b/src/models/transactions.rs
@@ -9,67 +9,67 @@ use serde::{Deserialize, Serialize};
 /// This struct should be created using the `InitializeTransactionBodyBuilder`
 /// The Builder derivation allows for the automatic implementation of the builder pattern.
 #[derive(Serialize, Debug, Default, Builder)]
-pub struct InitializeTransactionBody<'a> {
+pub struct InitializeTransactionBody {
     /// Amount should be in the smallest unit of the currency e.g. kobo if in NGN and cents if in USD
-    amount: &'a str,
+    amount: String,
     /// Customer's email address
-    email: &'a str,
+    email: String,
     /// Currency in which amount should be charged (NGN, GHS, ZAR or USD). Defaults to your integration currency.
     #[builder(default = "None")]
     currency: Option<Currency>,
     /// Unique transaction reference. Only -, ., = and alphanumeric characters allowed.
     #[builder(default = "None")]
-    reference: Option<&'a str>,
+    reference: Option<String>,
     /// Fully qualified url, e.g. https://example.com/ . Use this to override the callback url provided on the dashboard for this transaction
     #[builder(default = "None")]
-    callback_url: Option<&'a str>,
+    callback_url: Option<String>,
     /// If transaction is to create a subscription to a predefined plan, provide plan code here. This would invalidate the value provided in `amount`
     #[builder(default = "None")]
-    plan: Option<&'a str>,
+    plan: Option<String>,
     /// Number of times to charge customer during subscription to plan
     #[builder(default = "None")]
     invoice_limit: Option<u32>,
     /// Stringified JSON object of custom data. Kindly check the `Metadata` struct for more information.
     #[builder(default = "None")]
-    metadata: Option<&'a str>,
+    metadata: Option<String>,
     /// An array of payment channels to control what channels you want to make available to the user to make a payment with.
     /// Available channels include: `["card", "bank", "ussd", "qr", "mobile_money", "bank_transfer", "eft"]`
     #[builder(default = "None")]
     channels: Option<Vec<Channel>>,
     /// The split code of the transaction split. e.g. `SPL_98WF13Eb3w`
     #[builder(default = "None")]
-    split_code: Option<&'a str>,
+    split_code: Option<String>,
     /// The code for the subaccount that owns the payment. e.g. `ACCT_8f4s1eq7ml6rlzj`
     #[builder(default = "None")]
-    subaccount: Option<&'a str>,
+    subaccount: Option<String>,
     /// An amount used to override the split configuration for a single split payment.
     /// If set, the amount specified goes to the main account regardless of the split configuration.
     #[builder(default = "None")]
     transaction_charge: Option<u32>,
     /// Who bears Paystack charges? `account` or `subaccount` (defaults to account).
     #[builder(default = "None")]
-    bearer: Option<&'a str>,
+    bearer: Option<String>,
 }
 
 /// This struct is used to create a partial debit transaction body for creating a partial debit using the Paystack API.
 /// This struct should be created using the `PartialDebitTransactionBodyBuilder`
 /// The derive Builder allows for the automatic creation of the BuilderPattern
 #[derive(Debug, Clone, Serialize, Default, Builder)]
-pub struct PartialDebitTransactionBody<'a> {
+pub struct PartialDebitTransactionBody {
     /// Authorization Code
-    authorization_code: &'a str,
+    authorization_code: String,
     /// Specify the currency you want to debit. Allowed values are NGN or GHS.
     currency: Currency,
     /// Amount should be in the subunit of the supported currency
-    amount: &'a str,
+    amount: String,
     /// Customer's email address (attached to the authorization code)
-    email: &'a str,
+    email: String,
     /// Unique transaction reference. Only `-`, `.`, `=` and alphanumeric characters allowed.
     #[builder(default = "None")]
-    reference: Option<&'a str>,
+    reference: Option<String>,
     /// Minimum amount to charge
     #[builder(default = "None")]
-    at_least: Option<&'a str>,
+    at_least: Option<String>,
 }
 
 /// This struct represents the response of the Paystack transaction initialization.

--- a/tests/api/charge.rs
+++ b/tests/api/charge.rs
@@ -12,9 +12,9 @@ async fn charge_authorization_succeeds() {
     // In this test, an already created customer in the integration is used
     let amount = rng.gen_range(100..=100000).to_string();
     let charge = ChargeBodyBuilder::default()
-        .email("melyssa@example.net")
-        .amount(&amount)
-        .authorization_code("AUTH_9v3686msvt")
+        .email("melyssa@example.net".to_string())
+        .amount(amount)
+        .authorization_code("AUTH_9v3686msvt".to_string())
         .currency(Some(Currency::NGN))
         .channel(Some(vec![Channel::Card]))
         .transaction_charge(Some(100))

--- a/tests/api/subaccount.rs
+++ b/tests/api/subaccount.rs
@@ -16,11 +16,11 @@ async fn create_subaccount_passes_with_valid_data() {
     let (account_number, bank_code, bank_name) = get_bank_account_number_and_code();
 
     let body = CreateSubaccountBodyBuilder::default()
-        .business_name(&business_name)
-        .settlement_bank(&bank_code)
-        .account_number(&account_number)
+        .business_name(business_name)
+        .settlement_bank(bank_code)
+        .account_number(account_number.clone())
         .percentage_charge(18.2)
-        .description(&description)
+        .description(description)
         .build()
         .unwrap();
 
@@ -44,10 +44,10 @@ async fn create_subaccount_fails_with_invalid_data() {
 
     // Act
     let body = CreateSubaccountBodyBuilder::default()
-        .business_name("")
-        .settlement_bank("")
-        .account_number("")
-        .description("")
+        .business_name("".to_string())
+        .settlement_bank("".to_string())
+        .account_number("".to_string())
+        .description("".to_string())
         .percentage_charge(0.0)
         .build()
         .unwrap();
@@ -94,11 +94,11 @@ async fn fetch_subaccount_with_id_returns_a_valid_payload() {
 
     // Act
     let body = CreateSubaccountBodyBuilder::default()
-        .business_name(&business_name)
-        .settlement_bank(&bank_code)
-        .account_number(&account_number)
+        .business_name(business_name)
+        .settlement_bank(bank_code)
+        .account_number(account_number)
         .percentage_charge(18.2)
-        .description(&description)
+        .description(description)
         .build()
         .unwrap();
 
@@ -131,11 +131,11 @@ async fn fetch_subaccount_with_subaccount_code_returns_a_valid_payload() {
 
     // Act
     let body = CreateSubaccountBodyBuilder::default()
-        .business_name(&business_name)
-        .settlement_bank(&bank_code)
-        .account_number(&account_number)
+        .business_name(business_name)
+        .settlement_bank(bank_code)
+        .account_number(account_number)
         .percentage_charge(18.2)
-        .description(&description)
+        .description(description)
         .build()
         .unwrap();
 
@@ -168,11 +168,11 @@ async fn modify_subaccount_with_subaccount_id_returns_a_valid_payload() {
 
     // Act
     let body = CreateSubaccountBodyBuilder::default()
-        .business_name(&business_name)
-        .settlement_bank(&bank_code)
-        .account_number(&account_number)
+        .business_name(business_name)
+        .settlement_bank(bank_code.clone())
+        .account_number(account_number.clone())
         .percentage_charge(18.2)
-        .description(&description)
+        .description(description)
         .build()
         .unwrap();
 
@@ -184,11 +184,11 @@ async fn modify_subaccount_with_subaccount_id_returns_a_valid_payload() {
         .expect("Unable to Create a subaccount");
 
     let new_body = CreateSubaccountBodyBuilder::default()
-        .business_name("New Business Name")
-        .settlement_bank(&bank_code)
-        .account_number(&account_number)
+        .business_name("New Business Name".to_string())
+        .settlement_bank(bank_code)
+        .account_number(account_number)
         .percentage_charge(18.2)
-        .description("This should be modified")
+        .description("This should be modified".to_string())
         .build()
         .unwrap();
 
@@ -215,11 +215,11 @@ async fn modify_subaccount_with_subaccount_code_returns_a_valid_payload() {
 
     // Act
     let body = CreateSubaccountBodyBuilder::default()
-        .business_name(&business_name)
-        .settlement_bank(&bank_code)
-        .account_number(&account_number)
+        .business_name(business_name)
+        .settlement_bank(bank_code.clone())
+        .account_number(account_number.clone())
         .percentage_charge(18.2)
-        .description(&description)
+        .description(description)
         .build()
         .unwrap();
 
@@ -231,11 +231,11 @@ async fn modify_subaccount_with_subaccount_code_returns_a_valid_payload() {
         .expect("Unable to Create a subaccount");
 
     let new_body = CreateSubaccountBodyBuilder::default()
-        .business_name("New Business Name")
-        .settlement_bank(&bank_code)
-        .account_number(&account_number)
+        .business_name("New Business Name".to_string())
+        .settlement_bank(bank_code)
+        .account_number(account_number)
         .percentage_charge(18.2)
-        .description("This should be modified")
+        .description("This should be modified".to_string())
         .build()
         .unwrap();
 

--- a/tests/api/transaction.rs
+++ b/tests/api/transaction.rs
@@ -18,8 +18,8 @@ async fn initialize_transaction_valid() {
     let email: String = SafeEmail().fake();
     let amount: String = rng.gen_range(100..=100000).to_string();
     let body = InitializeTransactionBodyBuilder::default()
-        .amount(&amount)
-        .email(&email)
+        .amount(amount)
+        .email(email)
         .currency(Some(Currency::NGN))
         .channels(Some(vec![
             Channel::ApplePay,
@@ -52,8 +52,8 @@ async fn initialize_transaction_fails_when_currency_is_not_supported_by_merchant
     let email: String = SafeEmail().fake();
     let amount: String = rng.gen_range(100..=100000).to_string();
     let body = InitializeTransactionBodyBuilder::default()
-        .amount(&amount)
-        .email(&email)
+        .amount(amount)
+        .email(email)
         .currency(Some(Currency::USD))
         .channels(Some(vec![
             Channel::ApplePay,
@@ -87,8 +87,8 @@ async fn valid_transaction_is_verified() {
     let email: String = SafeEmail().fake();
     let amount: String = rng.gen_range(100..=100000).to_string();
     let body = InitializeTransactionBodyBuilder::default()
-        .amount(&amount)
-        .email(&email)
+        .amount(amount)
+        .email(email)
         .currency(Some(Currency::NGN))
         .channels(Some(vec![
             Channel::ApplePay,
@@ -306,9 +306,9 @@ async fn partial_debit_transaction_passes_or_fails_depending_on_merchant_status(
         .authorization_code
         .unwrap();
     let body = PartialDebitTransactionBodyBuilder::default()
-        .email(&email)
-        .amount("10000")
-        .authorization_code(&authorization_code)
+        .email(email)
+        .amount("10000".to_string())
+        .authorization_code(authorization_code)
         .currency(Currency::NGN)
         .build()
         .unwrap();

--- a/tests/api/transaction_split.rs
+++ b/tests/api/transaction_split.rs
@@ -21,11 +21,11 @@ async fn create_transaction_split_passes_with_valid_data() {
     let first_description: String = Sentence(5..10).fake();
 
     let body = CreateSubaccountBodyBuilder::default()
-        .business_name(&first_business_name)
-        .settlement_bank(&bank_code)
-        .account_number(&account_number)
+        .business_name(first_business_name)
+        .settlement_bank(bank_code.clone())
+        .account_number(account_number.clone())
         .percentage_charge(18.2)
-        .description(&first_description)
+        .description(first_description)
         .build()
         .unwrap();
 
@@ -40,11 +40,11 @@ async fn create_transaction_split_passes_with_valid_data() {
     let second_description: String = Sentence(5..10).fake();
 
     let body = CreateSubaccountBodyBuilder::default()
-        .business_name(&second_business_name)
-        .settlement_bank(&bank_code)
-        .account_number(&account_number)
+        .business_name(second_business_name)
+        .settlement_bank(bank_code.clone())
+        .account_number(account_number.clone())
         .percentage_charge(10.0)
-        .description(&second_description)
+        .description(second_description)
         .build()
         .unwrap();
 
@@ -70,7 +70,7 @@ async fn create_transaction_split_passes_with_valid_data() {
 
     // Create transaction split body
     let split_body = CreateTransactionSplitBodyBuilder::default()
-        .name(&txn_split_name)
+        .name(txn_split_name)
         .split_type(paystack::SplitType::Percentage)
         .currency(paystack::Currency::NGN)
         .bearer_type(paystack::BearerType::Subaccount)
@@ -79,7 +79,7 @@ async fn create_transaction_split_passes_with_valid_data() {
             first_subaccount_body.clone(),
             second_subaccount_body.clone(),
         ])
-        .bearer_subaccount(&first_subaccount_body.subaccount)
+        .bearer_subaccount(first_subaccount_body.subaccount)
         .build()
         .unwrap();
 


### PR DESCRIPTION
Changed structs field from &str to String. The reasons for this change are: 
- Using &str leads to complicated lifetime management.
- Data passed into the structs for the crates will likely be used only in the crate.
- It is easier to call `clone()` than to manage lifetimes.