### PR TITLE
implemented create transaction split route

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ async fn main() -> Result<(), PaystackAPIError> {
 }
 ```
 
+### Examples
+We provide some examples of use cases for the Paystack-rs crate. The examples are located in the [examples](examples) folder.
+
+
 ## Contributing
 
 See [CONTRIBUTING.md](/CONTRIBUTING.md) for information on contributing to paystack-rs.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,27 +1,28 @@
 //! Client
 //! =========
 //! This file contains the Paystack API client, and it associated endpoints.
-use crate::{HttpClient, TransactionEndpoints};
-use std::marker::PhantomData;
+use crate::{HttpClient, SubaccountEndpoints, TransactionEndpoints, TransactionSplitEndpoints};
 use std::sync::Arc;
 
 /// This is the entry level struct for the paystack API.
 /// it allows for authentication of the client
-pub struct PaystackClient<'a, T: HttpClient + Default> {
+pub struct PaystackClient<T: HttpClient + Default> {
     /// Transaction API route
-    pub transaction: TransactionEndpoints<'a, T>,
-
-    //Phantom data to keep compiler happy with lifetime
-    phantom: PhantomData<&'a T>,
+    pub transaction: TransactionEndpoints<T>,
+    /// Transaction Split API route
+    pub transaction_split: TransactionSplitEndpoints<T>,
+    /// Subaccount API route
+    pub subaccount: SubaccountEndpoints<T>,
 }
 
-impl<'a, T: HttpClient + Default> PaystackClient<'a, T> {
-    pub fn new(api_key: String) -> PaystackClient<'a, T> {
+impl<T: HttpClient + Default> PaystackClient<T> {
+    pub fn new(api_key: String) -> PaystackClient<T> {
         let http = Arc::new(T::default());
+        // TODO: consider making api_key work without cloning. Arc or Reference??
         PaystackClient {
-            transaction: TransactionEndpoints::new(api_key, Arc::clone(&http)),
-            // use less data
-            phantom: PhantomData,
+            transaction: TransactionEndpoints::new(api_key.clone(), Arc::clone(&http)),
+            transaction_split: TransactionSplitEndpoints::new(api_key.clone(), Arc::clone(&http)),
+            subaccount: SubaccountEndpoints::new(api_key.clone(), Arc::clone(&http)),
         }
     }
 }

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -1,4 +1,8 @@
+pub mod subaccount;
 pub mod transaction;
+pub mod transaction_split;
 
 // public re-export
+pub use subaccount::*;
 pub use transaction::*;
+pub use transaction_split::*;

--- a/src/endpoints/subaccount.rs
+++ b/src/endpoints/subaccount.rs
@@ -1,0 +1,56 @@
+//! Subaccounts
+//! ===========
+//! The Subaccounts API allows you to create and manage subaccounts on your integration.
+//! Subaccounts can be used to split payment between two accounts (your main account and a subaccount).
+
+use crate::{
+    HttpClient, PaystackAPIError, PaystackResult, Response, SubaccountRequest,
+    SubaccountsResponseData,
+};
+use std::sync::Arc;
+
+/// A struct to hold all functions in the subaccount API route
+#[derive(Debug, Clone)]
+pub struct SubaccountEndpoints<T: HttpClient + Default> {
+    key: String,
+    base_url: String,
+    http: Arc<T>,
+}
+
+impl<T: HttpClient + Default> SubaccountEndpoints<T> {
+    /// Constructor for the Subaccount object
+    pub fn new(key: String, http: Arc<T>) -> SubaccountEndpoints<T> {
+        let base_url = String::from("https://api.paystack.co/subaccount");
+        SubaccountEndpoints {
+            key,
+            base_url,
+            http,
+        }
+    }
+
+    /// Create a subaccount on your integration
+    ///
+    /// Takes in the following parameters
+    ///     - body: subaccount to create `SubaccountRequest`; this is constructed using the
+    ///      `SubaccountRequestBuilder`.
+    pub async fn create_subaccount(
+        &self,
+        subaccount_request: SubaccountRequest,
+    ) -> PaystackResult<SubaccountsResponseData> {
+        let url = self.base_url.to_string();
+        let body = serde_json::to_value(subaccount_request)
+            .map_err(|e| PaystackAPIError::Subaccount(e.to_string()))?;
+
+        let response = self.http.post(&url, &self.key, &body).await;
+
+        match response {
+            Ok(response) => {
+                let parsed_response: Response<SubaccountsResponseData> =
+                    serde_json::from_str(&response)
+                        .map_err(|e| PaystackAPIError::Subaccount(e.to_string()))?;
+                Ok(parsed_response)
+            }
+            Err(e) => Err(PaystackAPIError::Subaccount(e.to_string())),
+        }
+    }
+}

--- a/src/endpoints/transaction.rs
+++ b/src/endpoints/transaction.rs
@@ -7,33 +7,27 @@ use crate::{
     PaystackAPIError, PaystackResult, Response, Status, TransactionRequest,
     TransactionResponseData, TransactionStatusData, TransactionTimelineData, TransactionTotalData,
 };
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 /// A struct to hold all the functions of the transaction API endpoint
 #[derive(Debug, Clone)]
-pub struct TransactionEndpoints<'a, T: HttpClient + Default> {
+pub struct TransactionEndpoints<T: HttpClient + Default> {
     /// Paystack API Key
     key: String,
     /// Base URL for the transaction route
     base_url: String,
     /// Http client for the route
     http: Arc<T>,
-
-    // to keep compiler happy
-    phantom: PhantomData<&'a T>,
 }
 
-impl<'a, T: HttpClient + Default> TransactionEndpoints<'a, T> {
+impl<T: HttpClient + Default> TransactionEndpoints<T> {
     /// Constructor for the transaction object
-    pub fn new(key: String, http: Arc<T>) -> TransactionEndpoints<'a, T> {
+    pub fn new(key: String, http: Arc<T>) -> TransactionEndpoints<T> {
         let base_url = String::from("https://api.paystack.co/transaction");
         TransactionEndpoints {
             key,
             base_url,
             http,
-            // useless
-            phantom: PhantomData,
         }
     }
 

--- a/src/endpoints/transaction_split.rs
+++ b/src/endpoints/transaction_split.rs
@@ -1,0 +1,54 @@
+//! Transaction Split
+//! =================
+//! The Transaction Splits API enables merchants split the settlement for a
+//! transaction across their payout account, and one or more subaccounts.
+
+use crate::{
+    HttpClient, PaystackAPIError, PaystackResult, Response, TransactionSplitRequest,
+    TransactionSplitResponseData,
+};
+use std::sync::Arc;
+
+/// A struct to hold all the functions of the transaction split API endpoint
+#[derive(Debug, Clone)]
+pub struct TransactionSplitEndpoints<T: HttpClient + Default> {
+    key: String,
+    base_url: String,
+    http: Arc<T>,
+}
+
+impl<T: HttpClient + Default> TransactionSplitEndpoints<T> {
+    /// Constructor for the transaction object
+    pub fn new(key: String, http: Arc<T>) -> TransactionSplitEndpoints<T> {
+        let base_url = String::from("https://api.paystack.co/split");
+        TransactionSplitEndpoints {
+            key,
+            base_url,
+            http,
+        }
+    }
+
+    /// Create a split payment on your integration.
+    ///
+    /// This method takes a `TransactionSplitRequest` object as a parameter.
+    pub async fn create_transaction_split(
+        &self,
+        split_body: TransactionSplitRequest,
+    ) -> PaystackResult<TransactionSplitResponseData> {
+        let url = self.base_url.to_string();
+        let body = serde_json::to_value(split_body)
+            .map_err(|e| PaystackAPIError::TransactionSplit(e.to_string()))?;
+
+        let response = self.http.post(&url, &self.key, &body).await;
+
+        match response {
+            Ok(response) => {
+                let parsed_response: Response<TransactionSplitResponseData> =
+                    serde_json::from_str(&response)
+                        .map_err(|e| PaystackAPIError::TransactionSplit(e.to_string()))?;
+                Ok(parsed_response)
+            }
+            Err(e) => Err(PaystackAPIError::TransactionSplit(e.to_string())),
+        }
+    }
+}

--- a/src/models/bearer.rs
+++ b/src/models/bearer.rs
@@ -1,0 +1,60 @@
+//! Bearer Type
+//! =================
+//! This file contains the charge bearer option for the paystack API.
+
+use serde::Serialize;
+use std::fmt;
+
+/// Represents the type of bearer for a charge.
+///
+/// The `BearerType` enum defines the possible types of bearers for a charge, indicating who
+/// is responsible for the transaction split.
+///
+/// # Variants
+///
+/// - `Subaccount`: The subaccount bears the transaction split.
+/// - `Account`: The main account bears the transaction split.
+/// - `AllProportional`: The transaction is split proportionally to all accounts.
+/// - `All`: The transaction is paid by all accounts.
+///
+/// # Examples
+///
+/// ```
+/// use paystack::BearerType;
+///
+/// let subaccount_bearer = BearerType::Subaccount;
+/// let account_bearer = BearerType::Account;
+/// let all_proportional_bearer = BearerType::AllProportional;
+/// let all_bearer = BearerType::All;
+///
+/// println!("{:?}", subaccount_bearer); // Prints: Subaccount
+/// ```
+///
+/// The example demonstrates the usage of the `BearerType` enum, creating instances of each variant
+/// and printing their debug representation.
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum BearerType {
+    /// The subaccount bears the transaction split
+    #[default]
+    Subaccount,
+    /// The main account bears the transaction split
+    Account,
+    /// The transaction is split proportionally to all accounts
+    #[serde(rename = "all-proportional")]
+    AllProportional,
+    /// The transaction is paid by all accounts
+    All,
+}
+
+impl fmt::Display for BearerType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lowercase_string = match self {
+            BearerType::Subaccount => "subaccount",
+            BearerType::Account => "account",
+            BearerType::AllProportional => "all-proportional",
+            BearerType::All => "all",
+        };
+        write!(f, "{}", lowercase_string)
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,16 +1,24 @@
+pub mod bearer;
 pub mod channel;
 pub mod charge;
 pub mod currency;
 pub mod customer_model;
 pub mod response;
+pub mod split;
 pub mod status;
+pub mod subaccount_model;
 pub mod transaction_model;
+pub mod transaction_split_model;
 
 // public re-export
+pub use bearer::*;
 pub use channel::*;
 pub use charge::*;
 pub use currency::*;
 pub use customer_model::*;
 pub use response::*;
+pub use split::*;
 pub use status::*;
+pub use subaccount_model::*;
 pub use transaction_model::*;
+pub use transaction_split_model::*;

--- a/src/models/split.rs
+++ b/src/models/split.rs
@@ -1,0 +1,49 @@
+//! Split Type
+//! ===============
+//! This file contains the transaction split options for the paystack API.
+
+use serde::Serialize;
+use std::fmt;
+
+/// Represents the type of transaction split.
+///
+/// The `SplitType` enum defines the possible types of transaction splits that can be created,
+/// indicating whether the split is based on a percentage or a flat amount.
+///
+/// # Variants
+///
+/// - `Percentage`: A split based on a percentage.
+/// - `Flat`: A split based on an amount.
+///
+/// # Examples
+///
+/// ```
+/// use paystack::SplitType;
+///
+/// let percentage_split = SplitType::Percentage;
+/// let flat_split = SplitType::Flat;
+///
+/// println!("{:?}", percentage_split); // Prints: Percentage
+/// ```
+///
+/// The example demonstrates the usage of the `SplitType` enum, creating instances of each variant
+/// and printing their debug representation.
+#[derive(Debug, Serialize, Clone, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SplitType {
+    /// A split based on a percentage
+    #[default]
+    Percentage,
+    /// A split based on an amount
+    Flat,
+}
+
+impl fmt::Display for SplitType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lowercase_string = match self {
+            SplitType::Percentage => "percentage",
+            SplitType::Flat => "flat",
+        };
+        write!(f, "{}", lowercase_string)
+    }
+}

--- a/src/models/subaccount_model.rs
+++ b/src/models/subaccount_model.rs
@@ -1,0 +1,118 @@
+//! Subaccounts
+//! ==============
+//! This file contains the models for working with the subaccounts endpoint.
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+/// This struct is used to create the body for creating a subaccount on your integration.
+/// Use the `SubaccountRequestBuilder` to create this object.
+#[derive(Serialize, Debug, Builder, Default)]
+pub struct SubaccountRequest {
+    /// Name of business for subaccount
+    business_name: String,
+    /// Bank Code for the bank.
+    /// You can get the list of Bank Codes by calling the List Banks endpoint.
+    settlement_bank: String,
+    /// Bank Account Number
+    account_number: String,
+    /// The default percentage charged when receiving on behalf of this subaccount
+    percentage_charge: f32,
+    /// A description for this subaccount
+    description: String,
+    /// A contact email for the subaccount
+    #[builder(setter(into, strip_option), default)]
+    primary_contact_email: Option<String>,
+    /// A name for the contact person for this subaccount
+    #[builder(setter(into, strip_option), default)]
+    primary_contact_name: Option<String>,
+    /// A phone number to call for this subaccount
+    #[builder(setter(into, strip_option), default)]
+    primary_contact_phone: Option<String>,
+    /// Stringified JSON object.
+    /// Add a custom_fields attribute which has an array of objects if you would like the fields to be
+    /// added to your transaction when displayed on the dashboard.
+    /// Sample: {"custom_fields":[{"display_name":"Cart ID","variable_name": "cart_id","value": "8393"}]}
+    #[builder(setter(into, strip_option), default)]
+    metadata: Option<String>,
+}
+
+/// This struct represents the subaccount.
+/// It can be used as the payload for the API end points that require a subaccount as a payload.
+/// It is also possible to extract a single field from this struct to use as well.
+/// The Struct is constructed using the `SubaccountBodyBuilder`
+#[derive(Serialize, Debug, Clone, Builder)]
+pub struct SubaccountBody {
+    /// This is the subaccount code
+    pub subaccount: String,
+    /// This is the transaction share for the subaccount
+    pub share: f32,
+}
+
+/// Represents the data of th Subaccounts
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SubaccountData {
+    /// Sub account data
+    pub subaccount: SubaccountsResponseData,
+    /// Share of split assigned to this sub
+    pub share: u32,
+}
+
+/// Data of the list Subaccount response
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SubaccountsResponseData {
+    /// Integration ID of subaccount.
+    pub integration: Option<u32>,
+    /// Subaccount domain.
+    pub domain: Option<String>,
+    /// The code of the subaccount.
+    pub subaccount_code: String,
+    /// The name of the business associated with the subaccount.
+    pub business_name: String,
+    /// The description of the business associated with the subaccount.
+    pub description: Option<String>,
+    /// The name of the primary contact for the business, if available.
+    pub primary_contact_name: Option<String>,
+    /// The email of the primary contact for the business, if available.
+    pub primary_contact_email: Option<String>,
+    /// The phone number of the primary contact for the business, if available.
+    pub primary_contact_phone: Option<String>,
+    /// Additional metadata associated with the subaccount, if available.
+    pub metadata: Option<String>,
+    /// The percentage charge for transactions associated with the subaccount.
+    pub percentage_charge: Option<f32>,
+    /// Verification status of subaccount.
+    pub is_verified: Option<bool>,
+    /// The name of the settlement bank for the subaccount.
+    pub settlement_bank: String,
+    /// The account number of the subaccount.
+    pub account_number: String,
+    /// Settlement schedule of subaccount.
+    pub settlement_schedule: Option<String>,
+    /// The ID of the subaccount.
+    pub id: u32,
+    /// Creation time of subaccount.
+    #[serde(rename = "createdAt")]
+    pub created_at: Option<String>,
+    /// Last update time of subaccount.
+    #[serde(rename = "updatedAt")]
+    pub updated_at: Option<String>,
+}
+
+/// Represents the JSON response for fetch subaccount.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FetchSubaccountResponse {
+    /// The status of the JSON response.
+    pub status: bool,
+    /// The message associated with the JSON response.
+    pub message: String,
+    /// Fetch Subaccount response data.
+    pub data: SubaccountsResponseData,
+}
+
+/// This struct is used to create the body for deleting a subaccount on your integration.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteSubAccountBody {
+    /// This is the subaccount code
+    pub subaccount: String,
+}

--- a/src/models/transaction_split_model.rs
+++ b/src/models/transaction_split_model.rs
@@ -1,0 +1,76 @@
+//! Transaction Split Models
+//! ========================
+//! This file contains the models for working with the transaction splits endpoint.
+
+use crate::{BearerType, Currency, SplitType, SubaccountBody, SubaccountData};
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+/// This struct is used to create a split payment on your integration.
+/// The struct is constructed using the `TransactionSplitRequestBuilder`
+#[derive(Serialize, Debug, Default, Builder)]
+pub struct TransactionSplitRequest {
+    /// Name of the transaction split
+    name: String,
+    /// The type of transaction split you want to create
+    #[serde(rename = "type")]
+    split_type: SplitType,
+    /// Any of the supported currency
+    currency: Currency,
+    /// A list of object containing subaccount code and number of shares: `[{subaccount: ‘ACT_xxxxxxxxxx’, share: xxx},{...}]`
+    subaccounts: Vec<SubaccountBody>,
+    /// Any of subaccount
+    bearer_type: BearerType,
+    /// Subaccount code
+    bearer_subaccount: String,
+}
+
+/// Represents the percentage split data received in the JSON response.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TransactionSplitResponseData {
+    /// The ID of the percentage split.
+    pub id: u32,
+    /// The name of the percentage split.
+    pub name: String,
+    /// The type of the percentage split.
+    #[serde(rename = "type")]
+    pub split_type: String,
+    /// The currency used for the percentage split.
+    pub currency: String,
+    /// The integration associated with the percentage split.
+    pub integration: u32,
+    /// The domain associated with the percentage split.
+    pub domain: String,
+    /// The split code of the percentage split.
+    pub split_code: String,
+    /// Indicates whether the percentage split is active or not.
+    pub active: Option<bool>,
+    /// The bearer type of the percentage split.
+    pub bearer_type: String,
+    /// The subaccount ID of the bearer associated with the percentage split.
+    pub bearer_subaccount: u32,
+    /// The creation timestamp of the percentage split.
+    pub created_at: Option<String>,
+    /// The last update timestamp of the percentage split.
+    pub updated_at: Option<String>,
+    /// The list of subaccounts involved in the percentage split.
+    pub subaccounts: Vec<SubaccountData>,
+    /// The total count of subaccounts in the percentage split.
+    pub total_subaccounts: u32,
+}
+
+/// This struct is used to update a transaction split details on your integration.
+/// The struct is constructed using the `UpdateTransactionSplitRequestBuilder`
+#[derive(Serialize, Debug, Builder, Default)]
+pub struct UpdateTransactionSplitRequest {
+    /// Name of the transaction split
+    name: String,
+    /// True or False
+    active: bool,
+    /// Any of subaccount
+    #[builder(setter(into, strip_option), default)]
+    bearer_type: Option<BearerType>,
+    /// Subaccount code of a subaccount in the split group. This should be specified only if the `bearer_type is subaccount
+    #[builder(setter(into, strip_option), default)]
+    bearer_subaccount: Option<SubaccountBody>,
+}

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -29,7 +29,7 @@ pub fn get_api_key() -> String {
 }
 
 /// A function to get an instance of the paystack client for testing
-pub fn get_paystack_client() -> PaystackClient<'static, ReqwestClient> {
+pub fn get_paystack_client() -> PaystackClient<ReqwestClient> {
     let api_key = get_api_key();
 
     PaystackClient::<ReqwestClient>::new(api_key)

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,3 +1,4 @@
 pub mod charge;
 pub mod helpers;
 pub mod transaction;
+pub mod transaction_split;

--- a/tests/api/transaction.rs
+++ b/tests/api/transaction.rs
@@ -1,12 +1,13 @@
 use crate::helpers::get_paystack_client;
 use fake::faker::internet::en::SafeEmail;
 use fake::Fake;
-use paystack::{Channel, Currency, PartialDebitTransactionRequestBuilder, Status, TransactionRequestBuilder};
+use paystack::{
+    Channel, Currency, PartialDebitTransactionRequestBuilder, Status, TransactionRequestBuilder,
+};
 use rand::Rng;
-use std::error::Error;
 
 #[tokio::test]
-async fn initialize_transaction_valid() -> Result<(), Box<dyn Error>> {
+async fn initialize_transaction_valid() {
     // Arrange
     let client = get_paystack_client();
     let mut rng = rand::thread_rng();
@@ -24,20 +25,22 @@ async fn initialize_transaction_valid() -> Result<(), Box<dyn Error>> {
             Channel::BankTransfer,
             Channel::Bank,
         ])
-        .build()?;
+        .build()
+        .unwrap();
 
-    let res = client.transaction.initialize_transaction(body).await?;
+    let res = client
+        .transaction
+        .initialize_transaction(body)
+        .await
+        .expect("unable to create transaction");
 
     // Assert
     assert!(res.status);
     assert_eq!("Authorization URL created", res.message);
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn initialize_transaction_fails_when_currency_is_not_supported_by_merchant(
-) -> Result<(), Box<dyn Error>> {
+async fn initialize_transaction_fails_when_currency_is_not_supported_by_merchant() {
     // Arrange
     let client = get_paystack_client();
     let mut rng = rand::thread_rng();
@@ -54,7 +57,8 @@ async fn initialize_transaction_fails_when_currency_is_not_supported_by_merchant
             Channel::BankTransfer,
             Channel::Bank,
         ])
-        .build()?;
+        .build()
+        .expect("unable to build Transaction Request");
 
     let res = client.transaction.initialize_transaction(body).await;
 
@@ -66,12 +70,10 @@ async fn initialize_transaction_fails_when_currency_is_not_supported_by_merchant
             assert!(res.contains("status code: 403 Forbidden"));
         }
     }
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn valid_transaction_is_verified() -> Result<(), Box<dyn Error>> {
+async fn valid_transaction_is_verified() {
     // Arrange
     let client = get_paystack_client();
     let mut rng = rand::thread_rng();
@@ -107,12 +109,10 @@ async fn valid_transaction_is_verified() -> Result<(), Box<dyn Error>> {
     assert!(response.status);
     assert_eq!(response.message, "Verification successful");
     assert!(response.data.status.is_some());
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn list_specified_number_of_transactions_in_the_integration() -> Result<(), Box<dyn Error>> {
+async fn list_specified_number_of_transactions_in_the_integration() {
     // Arrange
     let client = get_paystack_client();
 
@@ -127,12 +127,10 @@ async fn list_specified_number_of_transactions_in_the_integration() -> Result<()
     assert_eq!(5, response.data.len());
     assert!(response.status);
     assert_eq!("Transactions retrieved", response.message);
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn list_transactions_passes_with_default_values() -> Result<(), Box<dyn Error>> {
+async fn list_transactions_passes_with_default_values() {
     // Arrange
     let client = get_paystack_client();
 
@@ -147,12 +145,10 @@ async fn list_transactions_passes_with_default_values() -> Result<(), Box<dyn Er
     assert!(response.status);
     assert_eq!(10, response.data.len());
     assert_eq!("Transactions retrieved", response.message);
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn fetch_transaction_succeeds() -> Result<(), Box<dyn Error>> {
+async fn fetch_transaction_succeeds() {
     // Arrange
     let client = get_paystack_client();
 
@@ -175,12 +171,10 @@ async fn fetch_transaction_succeeds() -> Result<(), Box<dyn Error>> {
         response.data[0].reference,
         fetched_transaction.data.reference
     );
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn view_transaction_timeline_passes_with_id() -> Result<(), Box<dyn Error>> {
+async fn view_transaction_timeline_passes_with_id() {
     // Arrange
     let client = get_paystack_client();
 
@@ -200,12 +194,10 @@ async fn view_transaction_timeline_passes_with_id() -> Result<(), Box<dyn Error>
     // Assert
     assert!(transaction_timeline.status);
     assert_eq!(transaction_timeline.message, "Timeline retrieved");
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn view_transaction_timeline_passes_with_reference() -> Result<(), Box<dyn Error>> {
+async fn view_transaction_timeline_passes_with_reference() {
     // Arrange
     let client = get_paystack_client();
 
@@ -227,12 +219,10 @@ async fn view_transaction_timeline_passes_with_reference() -> Result<(), Box<dyn
     // Assert
     assert!(transaction_timeline.status);
     assert_eq!(transaction_timeline.message, "Timeline retrieved");
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn view_transaction_timeline_fails_without_id_or_reference() -> Result<(), Box<dyn Error>> {
+async fn view_transaction_timeline_fails_without_id_or_reference() {
     // Arrange
     let client = get_paystack_client();
 
@@ -252,12 +242,10 @@ async fn view_transaction_timeline_fails_without_id_or_reference() -> Result<(),
             );
         }
     }
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn get_transaction_total_is_successful() -> Result<(), Box<dyn Error>> {
+async fn get_transaction_total_is_successful() {
     // Arrange
     let client = get_paystack_client();
 
@@ -273,12 +261,10 @@ async fn get_transaction_total_is_successful() -> Result<(), Box<dyn Error>> {
     assert_eq!(res.message, "Transaction totals");
     assert!(res.data.total_transactions.is_some());
     assert!(res.data.total_volume.is_some());
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn export_transaction_succeeds_with_default_parameters() -> Result<(), Box<dyn Error>> {
+async fn export_transaction_succeeds_with_default_parameters() {
     // Arrange
     let client = get_paystack_client();
 
@@ -293,12 +279,10 @@ async fn export_transaction_succeeds_with_default_parameters() -> Result<(), Box
     assert!(res.status);
     assert_eq!(res.message, "Export successful");
     assert!(!res.data.path.is_empty());
-
-    Ok(())
 }
 
 #[tokio::test]
-async fn partial_debit_transaction_passes_or_fails_depending_on_merchant_status() -> Result<(), Box<dyn Error>>{
+async fn partial_debit_transaction_passes_or_fails_depending_on_merchant_status() {
     // Arrange
     let client = get_paystack_client();
 
@@ -338,6 +322,4 @@ async fn partial_debit_transaction_passes_or_fails_depending_on_merchant_status(
             assert!(error.contains("status code: 400 Bad Request"));
         }
     }
-
-    Ok(())
 }

--- a/tests/api/transaction_split.rs
+++ b/tests/api/transaction_split.rs
@@ -1,0 +1,116 @@
+use crate::helpers::{get_bank_account_number_and_code, get_paystack_client};
+use fake::{
+    faker::{company::en::CompanyName, lorem::en::Sentence, name::en::FirstName},
+    Fake,
+};
+use paystack::{
+    Currency, PaystackClient, ReqwestClient, SubaccountBody, SubaccountBodyBuilder,
+    SubaccountRequestBuilder, TransactionSplitRequest, TransactionSplitRequestBuilder,
+};
+
+async fn create_subaccount_body(
+    client: &PaystackClient<ReqwestClient>,
+    percentage_charge: f32,
+    share: f32,
+) -> SubaccountBody {
+    let (account_number, bank_code, _bank_name) = get_bank_account_number_and_code();
+
+    let business_name: String = CompanyName().fake();
+    let description: String = Sentence(5..10).fake();
+
+    let body = SubaccountRequestBuilder::default()
+        .business_name(business_name)
+        .settlement_bank(bank_code.clone())
+        .account_number(account_number.clone())
+        .percentage_charge(percentage_charge)
+        .description(description)
+        .build()
+        .unwrap();
+
+    let subaccount = client
+        .subaccount
+        .create_subaccount(body)
+        .await
+        .expect("Unable to Create a subaccount");
+
+    SubaccountBodyBuilder::default()
+        .share(share)
+        .subaccount(subaccount.data.subaccount_code)
+        .build()
+        .unwrap()
+}
+
+async fn build_transaction_split(
+    client: &PaystackClient<ReqwestClient>,
+) -> (String, TransactionSplitRequest) {
+    let txn_split_name: String = FirstName().fake();
+
+    // Create first subaccount body
+    let first_subaccount_body = create_subaccount_body(client, 18.2, 80.0).await;
+
+    // Create second subaccount body
+    let second_subaccount_body = create_subaccount_body(client, 10.0, 10.0).await;
+
+    // Create transaction split body
+    let body = TransactionSplitRequestBuilder::default()
+        .name(txn_split_name.clone())
+        .split_type(paystack::SplitType::Percentage)
+        .currency(paystack::Currency::NGN)
+        .bearer_type(paystack::BearerType::Subaccount)
+        .subaccounts(vec![
+            first_subaccount_body.clone(),
+            second_subaccount_body.clone(),
+        ])
+        .bearer_subaccount(first_subaccount_body.subaccount)
+        .build()
+        .unwrap();
+
+    (txn_split_name, body)
+}
+
+#[tokio::test]
+async fn create_transaction_split_passes_with_valid_data() {
+    // Arrange
+    let client = get_paystack_client();
+    let (_, split_body) = build_transaction_split(&client).await;
+
+    // Act
+    let res = client
+        .transaction_split
+        .create_transaction_split(split_body)
+        .await
+        .expect("Failed to create transaction split");
+
+    // Assert
+    assert!(res.status);
+    assert_eq!(res.message, "Split created");
+    assert_eq!(res.data.currency, Currency::NGN.to_string());
+}
+
+#[tokio::test]
+async fn create_transaction_split_fails_with_invalid_data() {
+    //Arrange
+    let client = get_paystack_client();
+    let split_name: String = FirstName().fake();
+    let body = TransactionSplitRequestBuilder::default()
+        .name(split_name)
+        .split_type(paystack::SplitType::Flat)
+        .currency(paystack::Currency::EMPTY)
+        .subaccounts(vec![])
+        .bearer_type(paystack::BearerType::Subaccount)
+        .bearer_subaccount("non_existent_subaccount".to_string())
+        .build()
+        .unwrap();
+
+    //Act
+    let res = client
+        .transaction_split
+        .create_transaction_split(body)
+        .await;
+
+    if let Err(err) = res {
+        assert!(err.to_string().contains("status code: 400 Bad Request"));
+    } else {
+        panic!();
+    }
+}


### PR DESCRIPTION
The `create transaction split` route has been implemented. The route depended on the existence of a `subaccount,` so a `create subaccount` endpoint was implemented in the subaccount route. 

Relevant data objects and builder structs were implemented to achieve the results. The route was tested in both passing and failing tests, which were all successful.